### PR TITLE
WIP: Integrate Travis CI and publish to NPM

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -23,4 +23,3 @@ test/**/out
 
 #secrets
 *.pem
-lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: node_js
+
+node_js:
+  - v9
+
+install:
+  - npm install
+
+script:
+  - npm run compile
+
+deploy:
+  - provider: npm
+    email: okot08@gmail.com
+    api_key:
+      secure: "npm key"
+    skip_cleanup: true
+    on:
+      tags: true
+      repo: sparkplug/momoapi-node
+      branch: production
+
+  - provider: releases
+    api_key:
+      secure: "npm key"
+    file: 'lib'
+    skip_cleanup: true
+    on:
+      tags: true
+      repo: sparkplug/momoapi-node
+      branch: production
+
+cache:
+  - yarn
+  - node_modules


### PR DESCRIPTION
The major aim here is to publish the library on NPM when a PR is merged into master as per #7. We'll add Travis CI to facilitate this. Later we will use the CI to run automated tests