### PR TITLE
release 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 
-node_js: 8
+node_js: 10
 
 install:
   - npm ci
@@ -11,21 +11,11 @@ script:
   - npm run compile
 
 deploy:
-  - provider: npm
-    email: "$NPM_EMAIL"
-    api_key: "$NPM_TOKEN"
-    skip_cleanup: true
-    on:
-      tags: true
-      repo: sparkplug/momoapi-node
-      branch: master
-
-  - provider: releases
-    api_key: "$GITHUB_TOKEN"
-    file_glob: true
-    file: "lib/*"
-    skip_cleanup: true
-    on:
-      tags: true
-      repo: sparkplug/momoapi-node
-      branch: master
+  provider: script
+  skip_cleanup: true
+  script:
+    - npx semantic-release
+  on:
+    tags: false
+    repo: sparkplug/momoapi-node
+    branch: master

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 MTN MoMo API Client for Node JS.
 
 [![Build Status](https://travis-ci.com/sparkplug/momoapi-node.svg?branch=master)](https://travis-ci.com/sparkplug/momoapi-node)
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![NPM Version](https://badge.fury.io/js/mtn-momo.svg)](https://badge.fury.io/js/mtn-momo)
 ![Installs](https://img.shields.io/npm/dt/mtn-momo.svg)
+[![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/momo-api-developers/)
 
 ## Usage
 
@@ -49,12 +51,12 @@ As an example, you might configure the library like this:
 ```js
 const momo = require("mtn-momo");
 
-const { Collections, Disbursements } = momo({ callbackHost: process.env.CALLBACK_HOST });
+const { Collections, Disbursements } = momo.create({ callbackHost: process.env.CALLBACK_HOST });
 ```
 
 ## Collections
 
-The collections client can be created with the following paramaters. Note that the `userID` and `userSecret` for production are provided on the MTN OVA dashboard;
+The collections client can be created with the following paramaters. Note that the `userId` and `userSecret` for production are provided on the MTN OVA dashboard;
 
 - `primaryKey`: Primary Key for the `Collections` product.
 - `userId`: For sandbox, use the one generated with the `momo-sandbox` command.
@@ -93,7 +95,7 @@ const collections = Collections({
 ```js
 const momo = require("mtn-momo");
 
-const { Collections } = momo({ callbackHost: process.env.CALLBACK_HOST });
+const { Collections } = momo.create({ callbackHost: process.env.CALLBACK_HOST });
 
 const collections = Collections({
   userSecret: process.env.COLLECTIONS_USER_SECRET,
@@ -138,7 +140,7 @@ collections
 
 ## Disbursement
 
-The disbursements client can be created with the following paramaters. Note that the `userID` and `userSecret` for production are provided on the MTN OVA dashboard;
+The disbursements client can be created with the following paramaters. Note that the `userId` and `userSecret` for production are provided on the MTN OVA dashboard;
 
 - `primaryKey`: Primary Key for the `Disbursements` product.
 - `userId`: For sandbox, use the one generated with the `momo-sandbox` command.

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  extends: [
+    '@commitlint/config-conventional',
+  ],
+};

--- a/examples/collections.js
+++ b/examples/collections.js
@@ -1,6 +1,6 @@
 const momo = require("../lib/");
 
-const { Collections } = momo({
+const { Collections } = momo.create({
   callbackHost: process.env.CALLBACK_HOST
 });
 

--- a/examples/disbursements.js
+++ b/examples/disbursements.js
@@ -1,6 +1,6 @@
 const momo = require("../lib");
 
-const { Disbursements } = momo({ callbackHost: process.env.CALLBACK_HOST });
+const { Disbursements } = momo.create({ callbackHost: process.env.CALLBACK_HOST });
 
 // initialise collections
 const disbursements = Disbursements({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,184 @@
 {
   "name": "mtn-momo",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@commitlint/cli": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-6.2.0.tgz",
+      "integrity": "sha1-svgZDrCMzXjuplEUuGTzxl7KRmo=",
+      "dev": true,
+      "requires": {
+        "@commitlint/format": "^6.1.3",
+        "@commitlint/lint": "^6.2.0",
+        "@commitlint/load": "^6.1.3",
+        "@commitlint/read": "^6.1.3",
+        "babel-polyfill": "6.26.0",
+        "chalk": "2.3.1",
+        "get-stdin": "5.0.1",
+        "lodash.merge": "4.6.1",
+        "lodash.pick": "4.4.0",
+        "meow": "4.0.0"
+      }
+    },
+    "@commitlint/config-conventional": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-6.1.3.tgz",
+      "integrity": "sha1-bAburgTFrHicNhjfTVKu2on/uBA=",
+      "dev": true
+    },
+    "@commitlint/ensure": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-6.1.3.tgz",
+      "integrity": "sha1-gTtYyf364VNRty/mRqFi69tx6io=",
+      "dev": true,
+      "requires": {
+        "lodash.camelcase": "4.3.0",
+        "lodash.kebabcase": "4.1.1",
+        "lodash.snakecase": "4.1.1",
+        "lodash.startcase": "4.4.0",
+        "lodash.upperfirst": "4.3.1"
+      }
+    },
+    "@commitlint/execute-rule": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-6.1.3.tgz",
+      "integrity": "sha1-SJKOc27xXocQ0zKhXHyJlVXk4Qs=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "@commitlint/format": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-6.1.3.tgz",
+      "integrity": "sha1-QUuQSKmvVFh9qWIicXujMjR6veM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.23.0",
+        "chalk": "^2.0.1"
+      }
+    },
+    "@commitlint/is-ignored": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-6.1.3.tgz",
+      "integrity": "sha1-icm5ZKTWIoh1pXnCv1UtADc0t+g=",
+      "dev": true,
+      "requires": {
+        "semver": "5.5.0"
+      }
+    },
+    "@commitlint/lint": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-6.2.0.tgz",
+      "integrity": "sha1-148hl0W3c2LhuBTV9M7C7MMmZhk=",
+      "dev": true,
+      "requires": {
+        "@commitlint/is-ignored": "^6.1.3",
+        "@commitlint/parse": "^6.1.3",
+        "@commitlint/rules": "^6.2.0",
+        "babel-runtime": "^6.23.0",
+        "lodash.topairs": "4.3.0"
+      }
+    },
+    "@commitlint/load": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-6.1.3.tgz",
+      "integrity": "sha1-G+QHETl5WPMWz0BXepyHmhbwClQ=",
+      "dev": true,
+      "requires": {
+        "@commitlint/execute-rule": "^6.1.3",
+        "@commitlint/resolve-extends": "^6.1.3",
+        "babel-runtime": "^6.23.0",
+        "cosmiconfig": "^4.0.0",
+        "lodash.merge": "4.6.1",
+        "lodash.mergewith": "4.6.1",
+        "lodash.pick": "4.4.0",
+        "lodash.topairs": "4.3.0",
+        "resolve-from": "4.0.0"
+      }
+    },
+    "@commitlint/message": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-6.1.3.tgz",
+      "integrity": "sha1-XgRzMwyIcBYBDExWJwcjuAARRdI=",
+      "dev": true
+    },
+    "@commitlint/parse": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-6.1.3.tgz",
+      "integrity": "sha1-/x5NksJ81naBK7a512zYhTwNlAc=",
+      "dev": true,
+      "requires": {
+        "conventional-changelog-angular": "^1.3.3",
+        "conventional-commits-parser": "^2.1.0"
+      }
+    },
+    "@commitlint/read": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-6.1.3.tgz",
+      "integrity": "sha1-n52NtQ+/Z/MACSFlftbvrbjPnxo=",
+      "dev": true,
+      "requires": {
+        "@commitlint/top-level": "^6.1.3",
+        "@marionebl/sander": "^0.6.0",
+        "babel-runtime": "^6.23.0",
+        "git-raw-commits": "^1.3.0"
+      }
+    },
+    "@commitlint/resolve-extends": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-6.1.3.tgz",
+      "integrity": "sha1-9F/P5Dhg4F4489lNVMrtfdqkHiU=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "lodash.merge": "4.6.1",
+        "lodash.omit": "4.5.0",
+        "require-uncached": "^1.0.3",
+        "resolve-from": "^4.0.0",
+        "resolve-global": "^0.1.0"
+      }
+    },
+    "@commitlint/rules": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-6.2.0.tgz",
+      "integrity": "sha1-k5H2WhZVKCIEjUWjOrbON0aG4Gs=",
+      "dev": true,
+      "requires": {
+        "@commitlint/ensure": "^6.1.3",
+        "@commitlint/message": "^6.1.3",
+        "@commitlint/to-lines": "^6.1.3",
+        "babel-runtime": "^6.23.0"
+      }
+    },
+    "@commitlint/to-lines": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-6.1.3.tgz",
+      "integrity": "sha1-erFqAsrtjapH6Vkmm5YWRhCinQw=",
+      "dev": true
+    },
+    "@commitlint/top-level": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-6.1.3.tgz",
+      "integrity": "sha1-Em3LbeFnY0LGnNQiYUg/RHhUcpk=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.1.0"
+      }
+    },
+    "@marionebl/sander": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@marionebl/sander/-/sander-0.6.1.tgz",
+      "integrity": "sha1-GViWWHTyS8Ub5Ih1/rUNZC/EH3s=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.3",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.2"
+      }
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -131,6 +306,23 @@
       "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
       "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==",
       "dev": true
+    },
+    "@semantic-release/git": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-4.0.3.tgz",
+      "integrity": "sha512-XvW9mq4eegS5kQ4nNbgQjMC6AOO+9Oy6H+8iRTPCRkpJElhtecPUu/gqriZXEF/qqGXF891JKA3onCUjEwwWuQ==",
+      "dev": true,
+      "requires": {
+        "@semantic-release/error": "^2.1.0",
+        "aggregate-error": "^1.0.0",
+        "debug": "^3.1.0",
+        "dir-glob": "^2.0.0",
+        "execa": "^0.10.0",
+        "fs-extra": "^6.0.0",
+        "lodash": "^4.17.4",
+        "micromatch": "^3.1.4",
+        "p-reduce": "^1.0.0"
+      }
     },
     "@semantic-release/github": {
       "version": "5.2.9",
@@ -448,6 +640,16 @@
         "es6-promisify": "^5.0.0"
       }
     },
+    "aggregate-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-1.0.0.tgz",
+      "integrity": "sha1-iINE2tAiCnLjr1CQYRf0h3GSX6w=",
+      "dev": true,
+      "requires": {
+        "clean-stack": "^1.0.0",
+        "indent-string": "^3.0.0"
+      }
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -628,6 +830,35 @@
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
+      }
+    },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
+        }
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "balanced-match": {
@@ -812,6 +1043,21 @@
         }
       }
     },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "^0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
+    },
     "camelcase": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -879,6 +1125,12 @@
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
+    "ci-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+      "dev": true
+    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -901,6 +1153,12 @@
           }
         }
       }
+    },
+    "clean-stack": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
+      "integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE=",
+      "dev": true
     },
     "cli-table": {
       "version": "0.3.1",
@@ -1019,6 +1277,16 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "conventional-changelog-angular": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.6.6.tgz",
+      "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
+      "dev": true,
+      "requires": {
+        "compare-func": "^1.3.1",
+        "q": "^1.5.1"
+      }
+    },
     "conventional-changelog-writer": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.2.tgz",
@@ -1037,6 +1305,12 @@
         "through2": "^2.0.0"
       }
     },
+    "conventional-commit-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-2.2.0.tgz",
+      "integrity": "sha1-XblXOdbCEqy+e29lahG5QLqmiUY=",
+      "dev": true
+    },
     "conventional-commits-filter": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.1.tgz",
@@ -1047,10 +1321,31 @@
         "modify-values": "^1.0.0"
       }
     },
+    "conventional-commits-parser": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.1.7.tgz",
+      "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
+      "dev": true,
+      "requires": {
+        "JSONStream": "^1.0.4",
+        "is-text-path": "^1.0.0",
+        "lodash": "^4.2.1",
+        "meow": "^4.0.0",
+        "split2": "^2.0.0",
+        "through2": "^2.0.0",
+        "trim-off-newlines": "^1.0.0"
+      }
+    },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.4.tgz",
+      "integrity": "sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A==",
       "dev": true
     },
     "core-util-is": {
@@ -1058,6 +1353,18 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "cosmiconfig": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
+      "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
+      "dev": true,
+      "requires": {
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.9.0",
+        "parse-json": "^4.0.0",
+        "require-from-string": "^2.0.1"
+      }
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -1079,6 +1386,28 @@
       "dev": true,
       "requires": {
         "array-find-index": "^1.0.1"
+      }
+    },
+    "cz-conventional-changelog": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-2.1.0.tgz",
+      "integrity": "sha1-L0vHOQ4yROTfKT5ro1Hkx0Cnx2Q=",
+      "dev": true,
+      "requires": {
+        "conventional-commit-types": "^2.0.0",
+        "lodash.map": "^4.5.1",
+        "longest": "^1.0.1",
+        "right-pad": "^1.0.1",
+        "word-wrap": "^1.0.3"
+      }
+    },
+    "dargs": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
+      "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
       }
     },
     "dateformat": {
@@ -1593,6 +1922,17 @@
         "readable-stream": "^2.0.0"
       }
     },
+    "fs-extra": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+      "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1609,6 +1949,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
       "dev": true
     },
     "get-stream": {
@@ -1648,6 +1994,19 @@
         }
       }
     },
+    "git-raw-commits": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
+      "integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
+      "dev": true,
+      "requires": {
+        "dargs": "^4.0.1",
+        "lodash.template": "^4.0.2",
+        "meow": "^4.0.0",
+        "split2": "^2.0.0",
+        "through2": "^2.0.0"
+      }
+    },
     "glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -1667,6 +2026,15 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
       "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
       "dev": true
+    },
+    "global-dirs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.4"
+      }
     },
     "globby": {
       "version": "9.0.0",
@@ -1808,6 +2176,17 @@
         "debug": "^3.1.0"
       }
     },
+    "husky": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
+      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+      "dev": true,
+      "requires": {
+        "is-ci": "^1.0.10",
+        "normalize-path": "^1.0.0",
+        "strip-indent": "^2.0.0"
+      }
+    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -1940,6 +2319,15 @@
       "dev": true,
       "requires": {
         "builtin-modules": "^1.0.0"
+      }
+    },
+    "is-ci": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+      "dev": true,
+      "requires": {
+        "ci-info": "^1.5.0"
       }
     },
     "is-data-descriptor": {
@@ -2199,6 +2587,18 @@
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+      "dev": true
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
+    },
     "lodash.capitalize": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
@@ -2229,6 +2629,36 @@
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
       "dev": true
     },
+    "lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
+      "dev": true
+    },
+    "lodash.map": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
+      "dev": true
+    },
+    "lodash.mergewith": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
+      "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
+      "dev": true
+    },
+    "lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
+      "dev": true
+    },
     "lodash.pick": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
@@ -2241,10 +2671,47 @@
       "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
       "dev": true
     },
+    "lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40=",
+      "dev": true
+    },
+    "lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha1-lDbjTtJgk+1/+uGTYUQ1CRXZrdg=",
+      "dev": true
+    },
+    "lodash.template": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+      "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "~3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+      "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "~3.0.0"
+      }
+    },
     "lodash.toarray": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
       "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
+      "dev": true
+    },
+    "lodash.topairs": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.topairs/-/lodash.topairs-4.3.0.tgz",
+      "integrity": "sha1-O23qo31g+xFnE8RsXxfqGQ7EjWQ=",
       "dev": true
     },
     "lodash.uniq": {
@@ -2259,10 +2726,22 @@
       "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
       "dev": true
     },
+    "lodash.upperfirst": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
+      "integrity": "sha1-E2Xt9DFIBIHvDRxolXpe2Z1J984=",
+      "dev": true
+    },
     "lolex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.0.0.tgz",
       "integrity": "sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ==",
+      "dev": true
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
     "loud-rejection": {
@@ -2632,6 +3111,12 @@
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
       }
+    },
+    "normalize-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+      "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+      "dev": true
     },
     "normalize-url": {
       "version": "4.1.0",
@@ -6156,6 +6641,12 @@
         "esprima": "~4.0.0"
       }
     },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
+    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -6194,11 +6685,35 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+          "dev": true
+        }
+      }
     },
     "resolve": {
       "version": "1.9.0",
@@ -6214,6 +6729,15 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
+    },
+    "resolve-global": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-0.1.0.tgz",
+      "integrity": "sha1-j7As/Vt9sgEY6IYxHxWvlb0V+9k=",
+      "dev": true,
+      "requires": {
+        "global-dirs": "^0.1.0"
+      }
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -6232,6 +6756,21 @@
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "dev": true
+    },
+    "right-pad": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/right-pad/-/right-pad-1.0.1.tgz",
+      "integrity": "sha1-jKCMLLtbVedNr6lr9/0aJ9VoyNA=",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -7206,6 +7745,12 @@
       "requires": {
         "execa": "^0.10.0"
       }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
     },
     "wordwrap": {
       "version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "clean": "rm -r lib",
     "compile": "tsc -p tsconfig.json",
     "lint": "tslint --project tsconfig.json --config tslint.json",
-    "test": "NODE_ENV=test mocha -r ts-node/register \"./tests/**/*.ts\" --exit"
+    "test": "NODE_ENV=test mocha -r ts-node/register \"./tests/**/*.ts\" --exit",
+    "commitmsg": "commitlint -e $GIT_PARAMS"
   },
   "keywords": [
     "MTN",
@@ -28,6 +29,9 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
+    "@commitlint/cli": "^6.1.3",
+    "@commitlint/config-conventional": "^6.1.3",
+    "@semantic-release/git": "^4.0.2",
     "@types/bluebird": "^3.5.24",
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.0",
@@ -38,6 +42,8 @@
     "bluebird": "^3.5.3",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
+    "cz-conventional-changelog": "^2.1.0",
+    "husky": "^0.14.3",
     "mocha": "^5.2.0",
     "semantic-release": "^15.1.7",
     "sinon": "^7.2.3",

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  "branch": "master",
+};

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@
 import { AxiosError } from "axios";
 import program from "commander";
 
-import momo from "./";
+import * as momo from "./";
 import { Credentials } from "./common";
 
 const { version } = require("../package.json");
@@ -17,7 +17,7 @@ program
 
 const stringify = (obj: object | string) => JSON.stringify(obj, null, 2);
 
-const { Users } = momo({ callbackHost: program.host });
+const { Users } = momo.create({ callbackHost: program.host });
 
 const users = Users({ primaryKey: program.primaryKey });
 

--- a/src/collections.ts
+++ b/src/collections.ts
@@ -1,15 +1,16 @@
 import { AxiosInstance } from "axios";
 import uuid from "uuid/v4";
 
+import { getError } from "./errors";
+import { validateRequestToPay } from "./validate";
+
 import {
   Balance,
   FailureReason,
+  Party,
   PartyIdType,
-  Payer,
   TransactionStatus
 } from "./common";
-import { getError } from "./errors";
-import { validateRequestToPay } from "./validate";
 
 export interface PaymentRequest {
   /**
@@ -38,7 +39,7 @@ export interface PaymentRequest {
    *   - EMAIL - Validated to be a valid e-mail format. Validated with IsEmail
    *   - PARTY_CODE - UUID of the party. Validated with IsUuid
    */
-  payer: Payer;
+  payer: Party;
 
   /**
    * Message that will be written in the payer transaction history message field.
@@ -86,7 +87,7 @@ export interface Payment {
    *   - EMAIL - Validated to be a valid e-mail format. Validated with IsEmail
    *   - PARTY_CODE - UUID of the party. Validated with IsUuid
    */
-  payer: Payer;
+  payer: Party;
 
   /**
    * Message that will be written in the payer transaction history message field.

--- a/src/common.ts
+++ b/src/common.ts
@@ -82,7 +82,7 @@ export interface Balance {
   currency: string;
 }
 
-export interface Payer {
+export interface Party {
   partyIdType: PartyIdType;
   partyId: string;
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -6,75 +6,82 @@ interface ErrorBody {
   message: string;
 }
 
-export class ApprovalRejectedError extends Error {
+export class MtnMoMoError extends Error {
+  constructor(message?: string) {
+    super(message);
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class ApprovalRejectedError extends MtnMoMoError {
   public name = "ApprovalRejectedError";
 }
 
-export class ExpiredError extends Error {
+export class ExpiredError extends MtnMoMoError {
   public name = "ExpiredError";
 }
 
-export class InternalProcessingError extends Error {
+export class InternalProcessingError extends MtnMoMoError {
   public name = "InternalProcessingError";
 }
 
-export class InvalidCallbackUrlHostError extends Error {
+export class InvalidCallbackUrlHostError extends MtnMoMoError {
   public name = "InvalidCallbackUrlHostError";
 }
 
-export class InvalidCurrencyError extends Error {
+export class InvalidCurrencyError extends MtnMoMoError {
   public name = "InvalidCurrencyError";
 }
 
-export class NotAllowedTargetEnvironmentError extends Error {
+export class NotAllowedTargetEnvironmentError extends MtnMoMoError {
   public name = "NotAllowedTargetEnvironmentError";
 }
 
-export class NotAllowedError extends Error {
+export class NotAllowedError extends MtnMoMoError {
   public name = "NotAllowedError";
 }
 
-export class NotEnoughFundsError extends Error {
+export class NotEnoughFundsError extends MtnMoMoError {
   public name = "NotEnoughFundsError";
 }
 
-export class PayeeNotFoundError extends Error {
+export class PayeeNotFoundError extends MtnMoMoError {
   public name = "PayeeNotFoundError";
 }
 
-export class PayeeNotAllowedToReceiveError extends Error {
+export class PayeeNotAllowedToReceiveError extends MtnMoMoError {
   public name = "PayeeNotAllowedToReceiveError";
 }
 
-export class PayerLimitReachedError extends Error {
+export class PayerLimitReachedError extends MtnMoMoError {
   public name = "PayerLimitReachedError";
 }
 
-export class PayerNotFoundError extends Error {
+export class PayerNotFoundError extends MtnMoMoError {
   public name = "PayerNotFoundError";
 }
 
-export class PaymentNotApprovedError extends Error {
+export class PaymentNotApprovedError extends MtnMoMoError {
   public name = "PaymentNotApprovedError";
 }
 
-export class ResourceAlreadyExistError extends Error {
+export class ResourceAlreadyExistError extends MtnMoMoError {
   public name = "ResourceAlreadyExistError";
 }
 
-export class ResourceNotFoundError extends Error {
+export class ResourceNotFoundError extends MtnMoMoError {
   public name = "ResourceNotFoundError";
 }
 
-export class ServiceUnavailableError extends Error {
+export class ServiceUnavailableError extends MtnMoMoError {
   public name = "NotAllowedTargetEnvironment";
 }
 
-export class TransactionCancelledError extends Error {
+export class TransactionCancelledError extends MtnMoMoError {
   public name = "TransactionCancelledError";
 }
 
-export class UnspecifiedError extends Error {
+export class UnspecifiedError extends MtnMoMoError {
   public name = "ResourceAlreadyExistError";
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,15 @@
+export { Payment, PaymentRequest } from "./collections";
+export { Transfer, TransferRequest } from "./disbursements";
+export * from "./errors";
+export {
+  PartyIdType,
+  Party as Payer,
+  Environment,
+  FailureReason,
+  GlobalConfig,
+  ProductConfig
+} from "./common";
+
 import { AxiosInstance } from "axios";
 
 import Collections from "./collections";
@@ -7,7 +19,7 @@ import Users from "./users";
 import {
   authorizeCollections,
   authorizeDisbursements,
-  createTokenRefresher,
+  createTokenRefresher
 } from "./auth";
 import { createAuthClient, createClient } from "./client";
 import {
@@ -24,7 +36,7 @@ import {
   SubscriptionConfig
 } from "./common";
 
-interface MomoClient {
+export interface MomoClient {
   Collections(productConfig: ProductConfig): Collections;
   Disbursements(productConfig: ProductConfig): Disbursements;
   Users(subscription: SubscriptionConfig): Users;
@@ -35,7 +47,7 @@ const defaultGlobalConfig: GlobalConfig = {
   environment: Environment.SANDBOX
 };
 
-export = (globalConfig: GlobalConfig): MomoClient => {
+export function create(globalConfig: GlobalConfig): MomoClient {
   validateGlobalConfig(globalConfig);
 
   return {
@@ -84,4 +96,4 @@ export = (globalConfig: GlobalConfig): MomoClient => {
       return new Users(client);
     }
   };
-};
+}


### PR DESCRIPTION
Preparing next release

- adds semantic release
- removes CommonJS export so that the library can expose types, errors and other useful code (this is breaking change, hence v1.0.0)
- few renames here and there

Note: We are releasing as 1.0.0 so that everyone using `^0.1.1` doesn't get automatically upgraded to the new incompatible version. The interface is expected to remain fairly stable after this change.